### PR TITLE
test: deflake flaky tests by mocking randomness and time

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,79 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.0);
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    jest.useFakeTimers();
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.0) // shouldFail = false
+      .mockReturnValueOnce(0.0); // delay = 0ms
+
+    const promise = flakyApiCall();
+    jest.runAllTimers();
+
+    await expect(promise).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0.0); // choose min delay
+
+    const p = randomDelay(50, 150);
+
+    jest.advanceTimersByTime(50);
+    await expect(p).resolves.toBeUndefined();
   });
 
   test('multiple random conditions', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01T00:00:00.001Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
+
     expect(milliseconds % 7).not.toBe(0);
   });
 
   test('memory-based flakiness using object references', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.8) // obj1.value
+      .mockReturnValueOnce(0.2); // obj2.value
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });


### PR DESCRIPTION
- **Root cause:** "Intentionally Flaky Tests random boolean should be true" asserted `randomBoolean()` is always `true` while it uses `Math.random() > 0.5`, making it inherently nondeterministic. Other tests were brittle due to randomness, timing, and async variability.
- **Proposed fix:** Eliminated randomness in tests by mocking `Math.random` with deterministic returns and restoring after each test; used `jest.useFakeTimers()`/`jest.setSystemTime()` to control time and dates; isolated async behavior by injecting deterministic parameters or mocking calls; replaced exact/timing-based assertions with deterministic checks.
- **Verification:** **Verification:** 2/2 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)