### PR TITLE
test: deflake tests by mocking Math.random and timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,31 +1,60 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    // First call determines whether to add noise; return <= 0.8 to avoid noise
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.1);
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    jest.useFakeTimers();
+    // First random controls failure (<= 0.7 => success); second controls delay
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.1) // shouldFail = false
+      .mockReturnValueOnce(0);  // delay = 0ms
+
+    const promise = flakyApiCall();
+    await jest.runAllTimersAsync();
+    await expect(promise).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
+    jest.useFakeTimers();
+    // Force min delay
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
     const startTime = Date.now();
-    await randomDelay(50, 150);
+    const promise = randomDelay(50, 150);
+
+    await jest.advanceTimersByTimeAsync(50);
+    await promise;
+
     const endTime = Date.now();
     const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+    expect(duration).toBe(50);
   });
 
   test('multiple random conditions', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
@@ -34,6 +63,10 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    // Freeze time to a millisecond not divisible by 7
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.001Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
     
@@ -41,6 +74,11 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('memory-based flakiness using object references', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.8) // obj1.value
+      .mockReturnValueOnce(0.2); // obj2.value
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
     


### PR DESCRIPTION
- **Root cause:** `Intentionally Flaky Tests random boolean should be true` failed intermittently because `randomBoolean()` uses `Math.random()` while the test always asserts `true`, causing ~50% failures (per `/workspace/repo/flaky-tests-output/flaky-test-1.json`).
- **Proposed fix:** Make tests deterministic by mocking `Math.random` with `jest.spyOn(Math, 'random')`, using `jest.useFakeTimers()` and advancing timers, freezing system time for date-based checks, and adding `afterEach` to restore mocks and real timers. Optionally refactor utils to inject RNG/time dependencies and use `jest.retryTimes(2)` as a temporary CI mitigation.
- **Verification:** **Verification:** 2/2 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)