### PR TITLE
test: deflake random/time tests via Math.random mocks and fake timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,75 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.1);
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    jest.useFakeTimers();
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.0) // shouldFail -> false
+      .mockReturnValueOnce(0.0); // delay -> 0ms
+
+    const p = flakyApiCall();
+    jest.runAllTimers();
+    await expect(p).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0.3);
+
     const startTime = Date.now();
-    await randomDelay(50, 150);
+    const p = randomDelay(50, 150);
+    jest.advanceTimersByTime(80); // 50 + floor(0.3 * 101) = 80
+    await p;
+
     const endTime = Date.now();
     const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+    expect(duration).toBe(80);
   });
 
   test('multiple random conditions', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01T00:00:00.123Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
+
     expect(milliseconds % 7).not.toBe(0);
   });
 
   test('memory-based flakiness using object references', () => {
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.8).mockReturnValueOnce(0.2);
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });


### PR DESCRIPTION
- **Root cause:** The test "Intentionally Flaky Tests random boolean should be true" and others relied on real randomness/time. `randomBoolean()` returns `Math.random() > 0.5`, causing ~50% failures.
- **Proposed fix:** Replace nondeterminism in tests with explicit controls: mock `Math.random` per case, use `jest.useFakeTimers()` and `jest.setSystemTime()` for time/date, adjust assertions to properties/ranges when appropriate, and clean up with `afterEach(() => { jest.useRealTimers(); jest.restoreAllMocks(); })`.
- **Verification:** **Verification:** 2/2 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)