### PR TITLE
test: deflake random boolean by injecting RNG and fake timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,7 +1,13 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });


### PR DESCRIPTION
- **Root cause:** Nondeterminism in the test Intentionally Flaky Tests random boolean should be true — `randomBoolean()` uses `Math.random()` while the test asserts `true`, yielding ~50% pass rate (evidence: `times_flaked: 5` in CI job "test-node" from `/workspace/repo/flaky-tests-output/flaky-test-1.json`).
- **Proposed fix:** Remove randomness from tests by injecting or mocking RNG/timers. For this test, make RNG deterministic (e.g., `jest.spyOn(Math, 'random').mockReturnValue(0.9)` or pass an injected `rng` returning `0.9`); control timers with `jest.useFakeTimers()` where timing is involved; and add cleanup with `afterEach(() => { jest.restoreAllMocks(); jest.useRealTimers(); })`.
- **Verification:** 2/2 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)