### PR TITLE
fix(tests): deflake random-dependent tests via injected RNG/timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,31 +1,45 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
   test('random boolean should be true', () => {
-    const result = randomBoolean();
+    const result = randomBoolean(() => 0.9);
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
-    const result = unstableCounter();
+    const result = unstableCounter(() => 0.5);
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
+    const result = await flakyApiCall({ rng: () => 0.9, failRate: 0.3 });
     expect(result).toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+    jest.useFakeTimers();
+
+    let resolved = false;
+    const promise = randomDelay(50, 150, () => 0, setTimeout).then(() => {
+      resolved = true;
+    });
+
+    jest.advanceTimersByTime(49);
+    expect(resolved).toBe(false);
+
+    jest.advanceTimersByTime(1);
+    await promise;
+    expect(resolved).toBe(true);
   });
 
   test('multiple random conditions', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
@@ -34,6 +48,9 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.123Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
     
@@ -41,6 +58,9 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('memory-based flakiness using object references', () => {
+    const randomSpy = jest.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0.9).mockReturnValueOnce(0.1);
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
     

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,39 @@
-export function randomBoolean(): boolean {
-  return Math.random() > 0.5;
+export function randomBoolean(rng: () => number = Math.random): boolean {
+  return rng() > 0.5;
 }
 
-export function randomDelay(min: number = 100, max: number = 1000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
+type TimerFn = (handler: (...args: any[]) => void, timeout?: number) => any;
+
+export function randomDelay(
+  min: number = 100,
+  max: number = 1000,
+  rng: () => number = Math.random,
+  timer: TimerFn = setTimeout,
+): Promise<void> {
+  const delay = Math.floor(rng() * (max - min + 1)) + min;
+  return new Promise(resolve => timer(resolve, delay));
 }
 
-export function flakyApiCall(): Promise<string> {
+interface FlakyApiOptions {
+  rng?: () => number;
+  failRate?: number;
+  timer?: TimerFn;
+  delayMax?: number;
+}
+
+export function flakyApiCall(options: FlakyApiOptions = {}): Promise<string> {
+  const {
+    rng = Math.random,
+    failRate = 0.3,
+    timer = setTimeout,
+    delayMax = 500,
+  } = options;
+
   return new Promise((resolve, reject) => {
-    const shouldFail = Math.random() > 0.7;
-    const delay = Math.random() * 500;
-    
-    setTimeout(() => {
+    const shouldFail = rng() < failRate;
+    const delay = rng() * delayMax;
+
+    timer(() => {
       if (shouldFail) {
         reject(new Error('Network timeout'));
       } else {
@@ -22,8 +43,8 @@ export function flakyApiCall(): Promise<string> {
   });
 }
 
-export function unstableCounter(): number {
+export function unstableCounter(rng: () => number = Math.random): number {
   const base = 10;
-  const noise = Math.random() > 0.8 ? Math.floor(Math.random() * 3) - 1 : 0;
+  const noise = rng() > 0.8 ? Math.floor(rng() * 3) - 1 : 0;
   return base + noise;
 }


### PR DESCRIPTION
- **Root cause:** The test Intentionally Flaky Tests random boolean should be true asserted a constant true while `randomBoolean()` uses `Math.random() > 0.5`, causing ~50% failures.
- **Proposed fix:** Refactor utils to accept injectable RNG/timers (defaults to `Math.random`/`setTimeout`); update tests to stub RNG with `jest.spyOn(Math, 'random')` and use fake timers/system time; replace chance-based assertions with deterministic branch/invariant checks across `unstableCounter`, `flakyApiCall`, `randomDelay`, multi-random, date-based, and memory-based cases; add `afterEach(jest.restoreAllMocks)` to prevent leakage.
- **Verification:** 2/2 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)