### PR TITLE
test(flaky): make randomness/timing deterministic with mocks

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,9 +1,16 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
   test('random boolean should be true', () => {
-    const result = randomBoolean();
-    expect(result).toBe(true);
+    const rnd = jest.spyOn(Math, 'random');
+    rnd.mockReturnValueOnce(0.9);
+    expect(randomBoolean()).toBe(true);
+    rnd.mockReturnValueOnce(0.1);
+    expect(randomBoolean()).toBe(false);
   });
 
   test('unstable counter should equal exactly 10', () => {


### PR DESCRIPTION
- **Root cause:** Several tests asserted random outcomes, used real timers/dates, or compared random values, causing nondeterministic failures. In particular, Intentionally Flaky Tests random boolean should be true expected randomBoolean() to always be true while the implementation returns Math.random() > 0.5.
- **Proposed fix:** Make randomness and timing deterministic in tests: mock Math.random (including sequences for multi-call functions), use Jest fake timers to control async delays and resolve paths, freeze system time for date-based checks, and remove/repurpose tests that only compare random values. Add an afterEach to restore mocks and real timers; optionally allow RNG/time injection for direct stubbing.
- **Verification:** **Verification:** 1/1 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)