### PR TITLE
test: deflake 'random boolean should be true' via deterministic RNG

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,31 +1,51 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
   test('random boolean should be true', () => {
-    const result = randomBoolean();
+    const result = randomBoolean(() => 0.9);
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
-    const result = unstableCounter();
+    const result = unstableCounter(() => 0.0);
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    jest.useFakeTimers();
+    const rng = (() => {
+      const values = [0.1, 0]; // shouldFail=false, delay=0ms
+      let i = 0;
+      return () => (i < values.length ? values[i++] : values[values.length - 1]);
+    })();
+
+    const promise = flakyApiCall({ rng, timer: setTimeout });
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+    jest.useFakeTimers();
+    const p = randomDelay(50, 150, () => 0, setTimeout);
+    const done = jest.fn();
+    p.then(done);
+
+    expect(done).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(49);
+    await Promise.resolve();
+    expect(done).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    await Promise.resolve();
+    expect(done).toHaveBeenCalled();
   });
 
   test('multiple random conditions', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
@@ -34,6 +54,8 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2021-01-01T00:00:00.001Z'));
     const now = new Date();
     const milliseconds = now.getMilliseconds();
     
@@ -41,6 +63,10 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('memory-based flakiness using object references', () => {
+    jest.spyOn(Math, 'random')
+      .mockReturnValueOnce(0.8)
+      .mockReturnValueOnce(0.2);
+    
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
     

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,30 @@
-export function randomBoolean(): boolean {
-  return Math.random() > 0.5;
+export function randomBoolean(rng: () => number = Math.random): boolean {
+  return rng() > 0.5;
 }
 
-export function randomDelay(min: number = 100, max: number = 1000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
+export function randomDelay(
+  min: number = 100,
+  max: number = 1000,
+  rng: () => number = Math.random,
+  timer: (fn: (...args: any[]) => void, ms: number) => any = setTimeout
+): Promise<void> {
+  const delay = Math.floor(rng() * (max - min + 1)) + min;
+  return new Promise((resolve) => {
+    timer(resolve, delay);
+  });
 }
 
-export function flakyApiCall(): Promise<string> {
+export function flakyApiCall(
+  {
+    rng = Math.random,
+    timer = setTimeout,
+  }: { rng?: () => number; timer?: (fn: (...args: any[]) => void, ms: number) => any } = {}
+): Promise<string> {
   return new Promise((resolve, reject) => {
-    const shouldFail = Math.random() > 0.7;
-    const delay = Math.random() * 500;
-    
-    setTimeout(() => {
+    const shouldFail = rng() > 0.7;
+    const delay = rng() * 500;
+
+    timer(() => {
       if (shouldFail) {
         reject(new Error('Network timeout'));
       } else {
@@ -22,8 +34,8 @@ export function flakyApiCall(): Promise<string> {
   });
 }
 
-export function unstableCounter(): number {
+export function unstableCounter(rng: () => number = Math.random): number {
   const base = 10;
-  const noise = Math.random() > 0.8 ? Math.floor(Math.random() * 3) - 1 : 0;
+  const noise = rng() > 0.8 ? Math.floor(rng() * 3) - 1 : 0;
   return base + noise;
 }


### PR DESCRIPTION
- **Root cause:** The test `Intentionally Flaky Tests random boolean should be true` fails nondeterministically because `randomBoolean()` uses `Math.random() > 0.5`, so asserting true fails ~50% of runs.
- **Proposed fix:** Control nondeterminism by injecting RNG/timers into `utils` (e.g., `randomBoolean(rng)`, `randomDelay(min,max,rng)`, `flakyApiCall({rng,timer})`, `unstableCounter(rng)`), and in tests stub RNG sequences and use Jest fake timers; update assertions to validate behavior instead of chance.
- **Verification:** 1/1 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)