### PR TITLE
fix(tests): stabilize flakiness by mocking RNG/time and assertions

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,82 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
-  test('random boolean should be true', () => {
-    const result = randomBoolean();
-    expect(result).toBe(true);
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
-  test('unstable counter should equal exactly 10', () => {
-    const result = unstableCounter();
-    expect(result).toBe(10);
+  describe('randomBoolean', () => {
+    test('returns true when RNG > 0.5', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.9);
+      expect(randomBoolean()).toBe(true);
+    });
+
+    test('returns false when RNG <= 0.5', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.1);
+      expect(randomBoolean()).toBe(false);
+    });
   });
 
-  test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+  test('unstable counter should equal exactly 10 (noise disabled)', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.1); // ensures noise path not taken
+    expect(unstableCounter()).toBe(10);
   });
 
-  test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+  test('flaky API call should succeed deterministically', async () => {
+    jest.useFakeTimers();
+    const randSpy = jest.spyOn(Math, 'random');
+    randSpy.mockReturnValueOnce(0.1); // shouldFail false (0.1 > 0.7 is false)
+    randSpy.mockReturnValueOnce(0);   // delay 0ms
+
+    const p = flakyApiCall();
+
+    jest.runAllTimers();
+    await expect(p).resolves.toBe('Success');
   });
 
-  test('multiple random conditions', () => {
+  test('randomDelay resolves when timers advance', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0); // choose minimum delay
+
+    const p = randomDelay(50, 150);
+
+    jest.advanceTimersByTime(50);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  test('multiple random conditions deterministically true', () => {
+    const spy = jest.spyOn(Math, 'random');
+    spy
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
   });
 
-  test('date-based flakiness', () => {
+  test('date-based check with fixed system time', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.001Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
     expect(milliseconds % 7).not.toBe(0);
   });
 
-  test('memory-based flakiness using object references', () => {
+  test('memory-based comparison with controlled randomness', () => {
+    const spy = jest.spyOn(Math, 'random');
+    spy
+      .mockReturnValueOnce(0.8) // obj1.value
+      .mockReturnValueOnce(0.2); // obj2.value
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });


### PR DESCRIPTION
- **Root cause:** Nondeterminism from RNG/time; `randomBoolean()` returns `Math.random() > 0.5` while the test always expects `true`.
- **Proposed fix:** Control randomness with `jest.spyOn(Math, 'random')` to return known values and restore after each test; use `jest.useFakeTimers()`/`jest.setSystemTime()` and advance timers to resolve async deterministically; rewrite assertions to validate behavior instead of probability: test both branches of `randomBoolean` (covers "Intentionally Flaky Tests random boolean should be true"), adjust `unstableCounter`, stabilize `flakyApiCall`, avoid real clock/race-based timing by advancing timers; remove or refactor inherently probabilistic tests; optionally inject `rng`, `timer`, and `now` into utils for testability.
- **Verification:** **Verification:** Unable to run verification tests, so confidence in this fix is limited. Please review the proposed changes manually. See the troubleshooting guide (https://discuss.circleci.com/t/product-launch-agentic-capability-fixing-flaky-tests/53975) for assistance on how to ensure tests can be executed in subsequent runs.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)