### PR TITLE
test: deflake randomBoolean by mocking Math.random in test

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,7 +1,12 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });


### PR DESCRIPTION
- **Root cause:** The test `Intentionally Flaky Tests random boolean should be true` in `src/__tests__/flaky.test.ts` asserted `randomBoolean()` is always true, but `randomBoolean()` uses `Math.random() > 0.5`, making the outcome nondeterministic and failing ~50% of runs (evidenced by `flaky-tests-output/flaky-test-1.json` with `times_flaked: 5`).
- **Proposed fix:** Stub `Math.random` in that test via `jest.spyOn(Math, 'random').mockReturnValue(0.9)` to assert true (and optionally `0.1` to assert false); add `afterEach(() => jest.restoreAllMocks())` to prevent mock leakage. Longer term, inject an RNG and use fake timers to control randomness and timing across tests.
- **Verification:** **Verification:** 1/1 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)