### PR TITLE
test: stabilize flaky cases by mocking randomness and timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,84 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
+    jest.useFakeTimers();
+    const randomSpy = jest.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0.1); // shouldFail = false
+    randomSpy.mockReturnValueOnce(0);   // delay = 0ms
+
+    const promise = flakyApiCall();
+    jest.runAllTimers();
+    const result = await promise;
+
     expect(result).toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+    jest.spyOn(Math, 'random').mockReturnValue(0.4); // -> 90ms
+
     const startTime = Date.now();
-    await randomDelay(50, 150);
+    const p = randomDelay(50, 150);
+    jest.advanceTimersByTime(90);
+    await p;
     const endTime = Date.now();
+
     const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+    expect(duration).toBe(90);
   });
 
   test('multiple random conditions', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.001Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
+
     expect(milliseconds % 7).not.toBe(0);
   });
 
   test('memory-based flakiness using object references', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.1);
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });


### PR DESCRIPTION
- **Root cause:** Test "Intentionally Flaky Tests random boolean should be true" asserts true against nondeterministic `randomBoolean()` using `Math.random() > 0.5`.
- **Proposed fix:** Make tests deterministic: mock RNG/time (`jest.spyOn(Math, 'random')`, `jest.useFakeTimers()`, `jest.setSystemTime()`), adjust assertions to invariants/ranges, optionally add DI (`rng`, `timer`), and clean up with `afterEach`; reserve `jest.retryTimes(2)` only as last resort.
- **Verification:** **Verification:** Verification tests were executed, but the specific test still exhibits flakiness. The proposed changes may have addressed some issues but further investigation and fixes are needed.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)