### PR TITLE
test: deflake randomized tests via mocks and fake timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,9 +1,20 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
+  });
+
+  test('random boolean should be false', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.1);
+    const result = randomBoolean();
+    expect(result).toBe(false);
   });
 
   test('unstable counter should equal exactly 10', () => {


### PR DESCRIPTION
- **Root cause:** Tests asserted outcomes on randomness, timing, and current time; intermittent failures were inherent, not bugs. The test `Intentionally Flaky Tests random boolean should be true` relied on `Math.random()` returning > 0.5.
- **Proposed fix:** Make tests deterministic by mocking randomness (`jest.spyOn(Math, 'random')`), using fake timers (`jest.useFakeTimers()`/`jest.advanceTimersByTime()`), freezing time (`jest.setSystemTime(...)`), injecting RNG/time providers where helpful, controlling async success/failure, and asserting properties/ranges instead of chance.
- **Verification:** 1/1 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)