### PR TITLE
test: deflake RNG/time-based tests with mocks and fake timers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,26 @@
-export function randomBoolean(): boolean {
-  return Math.random() > 0.5;
+export function randomBoolean(rng: () => number = Math.random): boolean {
+  return rng() > 0.5;
 }
 
-export function randomDelay(min: number = 100, max: number = 1000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
+export function randomDelay(
+  min: number = 100,
+  max: number = 1000,
+  rng: () => number = Math.random,
+  timer: typeof setTimeout = setTimeout,
+): Promise<void> {
+  const delay = Math.floor(rng() * (max - min + 1)) + min;
+  return new Promise(resolve => timer(resolve, delay));
 }
 
-export function flakyApiCall(): Promise<string> {
+export function flakyApiCall({
+  rng = Math.random,
+  timer = setTimeout,
+}: { rng?: () => number; timer?: typeof setTimeout } = {}): Promise<string> {
   return new Promise((resolve, reject) => {
-    const shouldFail = Math.random() > 0.7;
-    const delay = Math.random() * 500;
-    
-    setTimeout(() => {
+    const shouldFail = rng() > 0.7;
+    const delay = rng() * 500;
+
+    timer(() => {
       if (shouldFail) {
         reject(new Error('Network timeout'));
       } else {
@@ -22,8 +30,8 @@ export function flakyApiCall(): Promise<string> {
   });
 }
 
-export function unstableCounter(): number {
+export function unstableCounter(rng: () => number = Math.random): number {
   const base = 10;
-  const noise = Math.random() > 0.8 ? Math.floor(Math.random() * 3) - 1 : 0;
+  const noise = rng() > 0.8 ? Math.floor(rng() * 3) - 1 : 0;
   return base + noise;
 }


### PR DESCRIPTION
**Chunk Results: **
- **Root cause:** `Intentionally Flaky Tests random boolean should be true` fails ~50% because `randomBoolean()` uses `Math.random() > 0.5` while the test asserts `true` unconditionally; other tests rely on nondeterministic randomness and real wall-clock time.
- **Proposed fix:** Mock `Math.random` deterministically per test with `jest.spyOn`, and use `jest.useFakeTimers()`/`jest.setSystemTime()` with timer advancement for time-dependent logic; optionally inject `rng`/`timer` into utils to enable deterministic tests; rewrite assertions to cover both branches or ranges and remove/replace purely probabilistic checks.
- **Verification:** **Verification:** Unable to run verification tests, so confidence in this fix is limited. Please review the proposed changes manually. See the [troubleshooting guide](https://discuss.circleci.com/t/product-launch-agentic-capability-fixing-flaky-tests/53975) for assistance on how to ensure tests can be executed in subsequent runs.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)