### PR TITLE
test: control randomness and timers for deterministic tests

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,89 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.6);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    // Ensure no noise is added
+    jest.spyOn(Math, 'random').mockReturnValue(0.0);
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    jest.useFakeTimers();
+    // First call: shouldFail (false); Second call: delay (0 ms)
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.0)
+      .mockReturnValueOnce(0.0);
+
+    const promise = flakyApiCall();
+
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
+    jest.useFakeTimers();
+    // Force the delay to be 50ms (min)
+    jest.spyOn(Math, 'random').mockReturnValue(0.0);
+
     const startTime = Date.now();
-    await randomDelay(50, 150);
+    const p = randomDelay(50, 150);
+
+    jest.advanceTimersByTime(50);
+    await p;
+
     const endTime = Date.now();
     const duration = endTime - startTime;
-    
+
     expect(duration).toBeLessThan(100);
   });
 
   test('multiple random conditions', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    // Set a time where milliseconds % 7 !== 0 (e.g., 1ms)
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.001Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
+
     expect(milliseconds % 7).not.toBe(0);
   });
 
   test('memory-based flakiness using object references', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9) // obj1.value
+      .mockReturnValueOnce(0.1); // obj2.value
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });


### PR DESCRIPTION
**Chunk Results:**
- **Root cause:** The test "Intentionally Flaky Tests random boolean should be true" is nondeterministic because `randomBoolean()` relies on `Math.random()` but the assertion expects `true` every run.
- **Proposed fix:** Control randomness with `jest.spyOn(Math, 'random')` to return fixed values/sequences; use `jest.useFakeTimers()` and advance timers for timing-based code; refine assertions (ranges or explicit values); mock async outcomes and freeze time (`jest.setSystemTime`/`Date.now`); clean up in `afterEach` via `jest.restoreAllMocks()` and `jest.useRealTimers()`; optionally inject RNG/clock dependencies for testability.
- **Verification:** **Verification:** Verification tests were executed, but the specific test still exhibits flakiness. The proposed changes may have addressed some issues but further investigation and fixes are needed.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)