### PR TITLE
test: stabilize flaky tests via deterministic randomness/time

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,31 +1,59 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    // Force no noise path
+    jest.spyOn(Math, 'random').mockReturnValue(0.0);
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    // Force success and deterministic delay
+    const randSpy = jest.spyOn(Math, 'random');
+    randSpy
+      .mockReturnValueOnce(0.0) // shouldFail = false
+      .mockReturnValueOnce(0.0); // delay = 0ms
+
+    jest.useFakeTimers();
+    const promise = flakyApiCall();
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
+    // Force minimal delay and use fake timers
+    jest.spyOn(Math, 'random').mockReturnValue(0.0); // delay = min
+    jest.useFakeTimers();
+
     const startTime = Date.now();
-    await randomDelay(50, 150);
+    const promise = randomDelay(50, 150);
+    jest.advanceTimersByTime(50);
+    await promise;
+
     const endTime = Date.now();
     const duration = endTime - startTime;
-    
     expect(duration).toBeLessThan(100);
   });
 
   test('multiple random conditions', () => {
+    const randSpy = jest.spyOn(Math, 'random');
+    randSpy
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
@@ -34,6 +62,7 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.008Z'));
     const now = new Date();
     const milliseconds = now.getMilliseconds();
     
@@ -41,6 +70,11 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('memory-based flakiness using object references', () => {
+    const randSpy = jest.spyOn(Math, 'random');
+    randSpy
+      .mockReturnValueOnce(0.9) // obj1.value
+      .mockReturnValueOnce(0.1); // obj2.value
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
     


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Uncontrolled use of `Math.random`, real timers, and system time caused nondeterministic assertions; specifically, Intentionally Flaky Tests random boolean should be true fails ~50% because `randomBoolean()` returns `Math.random() > 0.5`.
- **Proposed fix:** Control randomness with `jest.spyOn(Math, 'random')`, consider injectable RNGs, use modern fake timers with `jest.useFakeTimers()` and `jest.setSystemTime`, and replace nondeterministic assertions with deterministic expectations (e.g., explicit branches for true/false, timing via `advanceTimersByTime`).
- **Verification:** **Verification:** Verification tests were executed, but the specific test still exhibits flakiness. The proposed changes may have addressed some issues but further investigation and fixes are needed.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)