### PR TITLE
test: deflake tests via injectable RNG and fake timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,50 +1,49 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
-describe('Intentionally Flaky Tests', () => {
-  test('random boolean should be true', () => {
-    const result = randomBoolean();
-    expect(result).toBe(true);
+describe('Deterministic Tests', () => {
+  test('randomBoolean respects threshold with injected RNG', () => {
+    expect(randomBoolean(() => 0.9)).toBe(true);
+    expect(randomBoolean(() => 0.4)).toBe(false);
   });
 
-  test('unstable counter should equal exactly 10', () => {
-    const result = unstableCounter();
-    expect(result).toBe(10);
+  test('unstableCounter can be stable with injected RNG', () => {
+    expect(unstableCounter(() => 0.1)).toBe(10);
   });
 
-  test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+  test('unstableCounter adds noise when threshold passed', () => {
+    const seq = [0.9, 0.99];
+    let i = 0;
+    const rand = () => seq[i++ % seq.length];
+    expect(unstableCounter(rand)).toBe(11);
   });
 
-  test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+  test('randomDelay resolves with controlled timers', async () => {
+    jest.useFakeTimers();
+    const p = randomDelay(100, 100, () => 0.5, setTimeout);
+    jest.advanceTimersByTime(100);
+    await p;
+    jest.useRealTimers();
   });
 
-  test('multiple random conditions', () => {
-    const condition1 = Math.random() > 0.3;
-    const condition2 = Math.random() > 0.3;
-    const condition3 = Math.random() > 0.3;
-    
-    expect(condition1 && condition2 && condition3).toBe(true);
+  test('flakyApiCall resolves deterministically when shouldFail=false', async () => {
+    jest.useFakeTimers();
+    const seq = [0.1, 0]; // shouldFail false, delay 0ms
+    let i = 0;
+    const rand = () => seq[i++ % seq.length];
+    const promise = flakyApiCall(rand, setTimeout);
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe('Success');
+    jest.useRealTimers();
   });
 
-  test('date-based flakiness', () => {
-    const now = new Date();
-    const milliseconds = now.getMilliseconds();
-    
-    expect(milliseconds % 7).not.toBe(0);
-  });
-
-  test('memory-based flakiness using object references', () => {
-    const obj1 = { value: Math.random() };
-    const obj2 = { value: Math.random() };
-    
-    const compareResult = obj1.value > obj2.value;
-    expect(compareResult).toBe(true);
+  test('flakyApiCall rejects deterministically when shouldFail=true', async () => {
+    jest.useFakeTimers();
+    const seq = [0.9, 0]; // shouldFail true, delay 0ms
+    let i = 0;
+    const rand = () => seq[i++ % seq.length];
+    const promise = flakyApiCall(rand, setTimeout);
+    jest.runAllTimers();
+    await expect(promise).rejects.toThrow('Network timeout');
+    jest.useRealTimers();
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,18 @@
-export function randomBoolean(): boolean {
-  return Math.random() > 0.5;
+export function randomBoolean(rand: () => number = Math.random): boolean {
+  return rand() > 0.5;
 }
 
-export function randomDelay(min: number = 100, max: number = 1000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
+export function randomDelay(min: number = 100, max: number = 1000, rand: () => number = Math.random, timer: (cb: (...args: any[]) => void, ms: number) => any = setTimeout): Promise<void> {
+  const delay = Math.floor(rand() * (max - min + 1)) + min;
+  return new Promise(resolve => timer(resolve, delay));
 }
 
-export function flakyApiCall(): Promise<string> {
+export function flakyApiCall(rand: () => number = Math.random, timer: (cb: (...args: any[]) => void, ms: number) => any = setTimeout): Promise<string> {
   return new Promise((resolve, reject) => {
-    const shouldFail = Math.random() > 0.7;
-    const delay = Math.random() * 500;
-    
-    setTimeout(() => {
+    const shouldFail = rand() > 0.7;
+    const delay = rand() * 500;
+
+    timer(() => {
       if (shouldFail) {
         reject(new Error('Network timeout'));
       } else {
@@ -22,8 +22,8 @@ export function flakyApiCall(): Promise<string> {
   });
 }
 
-export function unstableCounter(): number {
+export function unstableCounter(rand: () => number = Math.random): number {
   const base = 10;
-  const noise = Math.random() > 0.8 ? Math.floor(Math.random() * 3) - 1 : 0;
+  const noise = rand() > 0.8 ? Math.floor(rand() * 3) - 1 : 0;
   return base + noise;
 }


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Non-deterministic randomness, time, and scheduling were asserted as deterministic outcomes; tests validated chance rather than behavior.
- **Proposed fix:** Inject RNG/clock into APIs (`randomBoolean`, `unstableCounter`, `flakyApiCall`), mock `Math.random`/`Date.now`, use Jest fake timers, and redesign tests to assert logic. Specifically deflake "Intentionally Flaky Tests random boolean should be true" by stubbing RNG (e.g., `jest.spyOn(Math, 'random').mockReturnValue(0.9)`) or passing a deterministic `rand`.
- **Verification:** **Verification:** Unable to run verification tests, so confidence in this fix is limited. See the [troubleshooting guide](https://discuss.circleci.com/t/product-launch-agentic-capability-fixing-flaky-tests/53975) for creating a `.circleci/cci-agent-setup.yml` file to ensure tests can be executed in subsequent runs.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)