### PR TITLE
test: deflake random boolean and timing-based tests

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,50 +1,96 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
+/**
+ * Stabilize tests by controlling randomness and time.
+ */
+
 describe('Intentionally Flaky Tests', () => {
-  test('random boolean should be true', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('randomBoolean returns true when RNG is high', () => {
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(0.99);
     const result = randomBoolean();
     expect(result).toBe(true);
+    spy.mockRestore();
   });
 
-  test('unstable counter should equal exactly 10', () => {
+  test('randomBoolean returns false when RNG is low', () => {
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(0.01);
+    const result = randomBoolean();
+    expect(result).toBe(false);
+    spy.mockRestore();
+  });
+
+  test('unstableCounter returns base when noise disabled', () => {
+    // First call <= 0.8 disables noise path
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
     const result = unstableCounter();
     expect(result).toBe(10);
+    spy.mockRestore();
   });
 
-  test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
+  test('flakyApiCall resolves on success branch', async () => {
+    jest.useFakeTimers();
+    // Sequence: shouldFail check (<=0.7 => success), delay (e.g., 0.1 => 50ms)
+    const randomSpy = jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.5) // shouldFail => false
+      .mockReturnValueOnce(0.1); // delay => 50ms
+
+    const p = flakyApiCall();
+    jest.advanceTimersByTime(50);
+    const result = await p;
     expect(result).toBe('Success');
+    randomSpy.mockRestore();
   });
 
-  test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+  test('randomDelay waits at least the minimum delay', async () => {
+    jest.useFakeTimers();
+    // Force min delay
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    const p = randomDelay(50, 150);
+    jest.advanceTimersByTime(50);
+    await expect(p).resolves.toBeUndefined();
+    randomSpy.mockRestore();
   });
 
-  test('multiple random conditions', () => {
+  test('multiple random conditions with deterministic true outcomes', () => {
+    const spy = jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.99)
+      .mockReturnValueOnce(0.99)
+      .mockReturnValueOnce(0.99);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
+    spy.mockRestore();
   });
 
-  test('date-based flakiness', () => {
+  test('date-based logic under fixed system time', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.001Z'));
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
     expect(milliseconds % 7).not.toBe(0);
   });
 
-  test('memory-based flakiness using object references', () => {
+  test('deterministic comparison between two random values', () => {
+    const spy = jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.1);
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Tests asserted specific random outcomes and nondeterministic timing; for example, "Intentionally Flaky Tests random boolean should be true" expects true despite randomBoolean() using Math.random() > 0.5, plus timing and async variability.
- **Proposed fix:** Control randomness with jest.spyOn(Math, 'random') and restore after each test; add true/false branch tests for randomBoolean; for unstableCounter, either drive RNG to produce zero noise or assert a small range; sequence RNG for multi-random and object-compare cases; stabilize timing with jest.useFakeTimers(), jest.setSystemTime(), and jest.advanceTimersByTime(); mock flakyApiCall to resolve/reject in dedicated tests; optionally inject rng/setTimeout into utils for deterministic testing.
- **Verification:** Unable to run verification tests, so confidence in this fix is limited. See the [troubleshooting guide](https://discuss.circleci.com/t/product-launch-agentic-capability-fixing-flaky-tests/53975) for creating a `.circleci/cci-agent-setup.yml` file to ensure tests can be executed in subsequent runs.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)