### PR TITLE
test: deflake flaky tests by controlling randomness and time

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,78 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
-describe('Intentionally Flaky Tests', () => {
-  test('random boolean should be true', () => {
-    const result = randomBoolean();
-    expect(result).toBe(true);
+describe('Intentionally Flaky Tests (stabilized)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
-  test('unstable counter should equal exactly 10', () => {
-    const result = unstableCounter();
-    expect(result).toBe(10);
+  test('random boolean deterministic both branches', () => {
+    jest.spyOn(Math, 'random')
+      .mockReturnValueOnce(0.99)
+      .mockReturnValueOnce(0.01);
+
+    expect(randomBoolean()).toBe(true);
+    expect(randomBoolean()).toBe(false);
   });
 
-  test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+  test('unstable counter returns base when noise off', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.0);
+    expect(unstableCounter()).toBe(10);
   });
 
-  test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+  test('flaky API call resolves when not failing', async () => {
+    jest.useFakeTimers();
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.0) // shouldFail -> false
+      .mockReturnValueOnce(0.0); // delay -> 0ms
+
+    const p = flakyApiCall();
+    jest.runAllTimers();
+    await expect(p).resolves.toBe('Success');
   });
 
-  test('multiple random conditions', () => {
+  test('randomDelay resolves deterministically with fake timers', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0.0); // choose min delay
+
+    const p = randomDelay(50, 150);
+    jest.advanceTimersByTime(50);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  test('multiple random conditions deterministic pass', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
   });
 
-  test('date-based flakiness', () => {
+  test('date-based behavior consistent with frozen time', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.001Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
     expect(milliseconds % 7).not.toBe(0);
   });
 
-  test('memory-based flakiness using object references', () => {
+  test('memory-based comparison deterministic', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.8)
+      .mockReturnValueOnce(0.2);
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Tests (e.g., Intentionally Flaky Tests random boolean should be true) assert probabilistic and timing-based outcomes using Math.random, random delays, and Date, making results nondeterministic.
- **Proposed fix:** Control randomness (jest.spyOn(Math, 'random') or inject RNG), control time with Jest fake timers and setSystemTime, and convert assertions to deterministic checks; reset mocks/timers in afterEach.
- **Verification:** **Verification:** Unable to run verification tests, so confidence in this fix is limited. See the [troubleshooting guide](https://discuss.circleci.com/t/product-launch-agentic-capability-fixing-flaky-tests/53975) for creating a `.circleci/cci-agent-setup.yml` file to ensure tests can be executed in subsequent runs.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)