### PR TITLE
fix(tests): deflake by injecting RNG and controlling timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,90 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
-describe('Intentionally Flaky Tests', () => {
-  test('random boolean should be true', () => {
-    const result = randomBoolean();
-    expect(result).toBe(true);
+describe('Intentionally Flaky Tests (made deterministic)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
-  test('unstable counter should equal exactly 10', () => {
-    const result = unstableCounter();
-    expect(result).toBe(10);
+  test('randomBoolean returns true when rand > 0.5', () => {
+    expect(randomBoolean(() => 0.6)).toBe(true);
   });
 
-  test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+  test('randomBoolean returns false when rand <= 0.5', () => {
+    expect(randomBoolean(() => 0.5)).toBe(false);
   });
 
-  test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+  test('unstableCounter returns 10 when no noise (rand <= 0.8)', () => {
+    expect(unstableCounter(() => 0.5)).toBe(10);
   });
 
-  test('multiple random conditions', () => {
+  test('unstableCounter increases by 1 when noise triggers', () => {
+    const seq = [0.9, 0.9]; // >0.8 then floor(0.9*3)-1 => 2-1 => +1
+    const rand = () => seq.shift() as number;
+    expect(unstableCounter(rand)).toBe(11);
+  });
+
+  test('unstableCounter decreases by 1 when noise triggers', () => {
+    const seq = [0.95, 0.0]; // >0.8 then floor(0*3)-1 => -1
+    const rand = () => seq.shift() as number;
+    expect(unstableCounter(rand)).toBe(9);
+  });
+
+  test('flakyApiCall resolves when forced to succeed', async () => {
+    jest.useFakeTimers();
+    const seq = [0.1, 0]; // shouldFail=false, delay=0
+    const rand = () => seq.shift() as number;
+    const p = flakyApiCall(rand, setTimeout);
+    jest.runAllTimers();
+    await expect(p).resolves.toBe('Success');
+  });
+
+  test('flakyApiCall rejects when forced to fail', async () => {
+    jest.useFakeTimers();
+    const seq = [0.9, 0]; // shouldFail=true, delay=0
+    const rand = () => seq.shift() as number;
+    const p = flakyApiCall(rand, setTimeout);
+    jest.runAllTimers();
+    await expect(p).rejects.toThrow('Network timeout');
+  });
+
+  test('randomDelay resolves after chosen delay using fake timers', async () => {
+    jest.useFakeTimers();
+    const p = randomDelay(50, 150, () => 0, setTimeout); // delay=50
+    jest.advanceTimersByTime(49);
+    let settled = false;
+    p.then(() => { settled = true; });
+    expect(settled).toBe(false);
+    jest.advanceTimersByTime(1);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  test('multiple random conditions deterministic true', () => {
+    const spy = jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
+    spy.mockRestore();
   });
 
-  test('date-based flakiness', () => {
+  test('date-based check using fixed system time', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.005Z'));
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
     expect(milliseconds % 7).not.toBe(0);
   });
 
-  test('memory-based flakiness using object references', () => {
-    const obj1 = { value: Math.random() };
-    const obj2 = { value: Math.random() };
-    
+  test('deterministic object value comparison', () => {
+    const obj1 = { value: 0.8 };
+    const obj2 = { value: 0.2 };
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,18 @@
-export function randomBoolean(): boolean {
-  return Math.random() > 0.5;
+export function randomBoolean(rand: () => number = Math.random): boolean {
+  return rand() > 0.5;
 }
 
-export function randomDelay(min: number = 100, max: number = 1000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
+export function randomDelay(min: number = 100, max: number = 1000, rand: () => number = Math.random, timer: (cb: (...args: any[]) => void, ms: number) => any = setTimeout): Promise<void> {
+  const delay = Math.floor(rand() * (max - min + 1)) + min;
+  return new Promise(resolve => timer(resolve, delay));
 }
 
-export function flakyApiCall(): Promise<string> {
+export function flakyApiCall(rand: () => number = Math.random, timer: (cb: (...args: any[]) => void, ms: number) => any = setTimeout): Promise<string> {
   return new Promise((resolve, reject) => {
-    const shouldFail = Math.random() > 0.7;
-    const delay = Math.random() * 500;
-    
-    setTimeout(() => {
+    const shouldFail = rand() > 0.7;
+    const delay = rand() * 500;
+
+    timer(() => {
       if (shouldFail) {
         reject(new Error('Network timeout'));
       } else {
@@ -22,8 +22,8 @@ export function flakyApiCall(): Promise<string> {
   });
 }
 
-export function unstableCounter(): number {
+export function unstableCounter(rand: () => number = Math.random): number {
   const base = 10;
-  const noise = Math.random() > 0.8 ? Math.floor(Math.random() * 3) - 1 : 0;
+  const noise = rand() > 0.8 ? Math.floor(rand() * 3) - 1 : 0;
   return base + noise;
 }


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Non-deterministic Math.random and timing assertions caused flaky outcomes; tests asserted probabilistic truths (e.g., Intentionally Flaky Tests random boolean should be true), leading to ~50% pass rates and intermittent failures.
- **Proposed fix:** Inject `rand`/`timer` into utils; use deterministic RNG in tests or mock `Math.random`; adopt Jest fake timers; rewrite probabilistic assertions to deterministic branch checks.
- **Verification:** **Verification:** 3/3 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)